### PR TITLE
use jakartatck.jar2shrinkwrap.EarFileProcessor for tests like com.sun.ts.tests.assembly.altDD that use EARs

### DIFF
--- a/src/main/java/tck/jakarta/platform/rewrite/AddArquillianDeployMethod.java
+++ b/src/main/java/tck/jakarta/platform/rewrite/AddArquillianDeployMethod.java
@@ -2,6 +2,7 @@ package tck.jakarta.platform.rewrite;
 
 import jakartatck.jar2shrinkwrap.Jar2ShrinkWrap;
 import jakartatck.jar2shrinkwrap.JarProcessor;
+import jakartatck.jar2shrinkwrap.EarFileProcessor;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
@@ -75,9 +76,11 @@ public class AddArquillianDeployMethod<ExecutionContext> extends JavaIsoVisitor<
                 String clInfo = ClassLoaderUtils.showClassLoaderHierarchy(this, "visitClassDeclaration");
                 System.out.println(clInfo);
                  */
-                JarProcessor war = Jar2ShrinkWrap.fromPackage(pkg);
+                JarProcessor jarProcessor = Jar2ShrinkWrap.fromPackage(pkg);
                 StringWriter methodCodeWriter = new StringWriter();
-                war.saveOutput(methodCodeWriter, false);
+                jarProcessor.saveOutput(methodCodeWriter, false);
+                boolean isEar = jarProcessor instanceof EarFileProcessor;
+
                 String methodCode = methodCodeWriter.toString();
                 if (methodCode.length() == 0) {
                     log.fine("No Jar2ShrinkWrap artifact, no code generated for package: " + pkg);
@@ -107,6 +110,9 @@ public class AddArquillianDeployMethod<ExecutionContext> extends JavaIsoVisitor<
                 maybeAddImport("org.jboss.shrinkwrap.api.ShrinkWrap");
                 maybeAddImport("org.jboss.shrinkwrap.api.spec.JavaArchive");
                 maybeAddImport("org.jboss.shrinkwrap.api.spec.WebArchive");
+                if ( isEar ) {
+                    maybeAddImport("org.jboss.shrinkwrap.api.spec.EnterpriseArchive");
+                }
                 maybeAddImport("jakartatck.jar2shrinkwrap.LibraryUtil");
                 maybeAddImport("java.util.List");
                 log.info("Added @Deployment method to class: "+classDecl.getType().getFullyQualifiedName());

--- a/src/test/java/tck/conversion/rewrite/AddArqDeploymentTest.java
+++ b/src/test/java/tck/conversion/rewrite/AddArqDeploymentTest.java
@@ -41,7 +41,7 @@ class LocalRecipe extends Recipe {
 public class AddArqDeploymentTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        Path testClasses = Paths.get("/Users/starksm/Dev/Jakarta/tck-rewrite-tools/target", "test-classes");
+        Path testClasses = Paths.get("target", "test-classes");
 
         spec
                 .recipe(new LocalRecipe())


### PR DESCRIPTION
https://github.com/scottmarlow/jakartaee-tck-tools/tree/jar2shrinkwrap started adding EAR support, needs a few more changes.  We need to decide where the removal of unneeded jar/classes should happen.

I think the filtering or removal of unneeded jar/classes could happen in:
1.  use of jakartatck.jar2shrinkwrap.LibraryUtil in https://github.com/starksm64/tck-rewrite-tools as current way but would involve rewrite recipe for updating the generated test code.
2.  use of custom filtering code and/or configuration settings in https://github.com/scottmarlow/jakartaee-tck-tools/tree/jar2shrinkwrap.  This would be adjusting code like https://github.com/scottmarlow/jakartaee-tck-tools/blob/jar2shrinkwrap/tools/jar2shrinkwrap/src/main/java/jakartatck/jar2shrinkwrap/EarFileProcessor.java#L93 to filter out certain jar names or classes within those jars.